### PR TITLE
setup: fix missing command requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Define how the participants form a network (.FBP DSL)
 
 Setup the network
 
-    msgflo-setup --graph ./myservice.fbp --broker amqp://localhost
+    msgflo-setup ./myservice.fbp --broker amqp://localhost
 
 
 ...

--- a/src/setup.coffee
+++ b/src/setup.coffee
@@ -8,6 +8,7 @@ async = require 'async'
 debug = require('debug')('msgflo:setup')
 child_process = require 'child_process'
 path = require 'path'
+program = require 'commander'
 
 addBindings = (broker, bindings, callback) ->
   addBinding = (b, cb) ->


### PR DESCRIPTION
Hi,
I tried running `msgflo-setup` but got the following error:

```
/Users/chad/dev/noflo-dev/msgflo/src/setup.coffee:279
    program["arguments"]('<graph.fbp/.json>').option('--broker <URL>', 'URL of
    ^
ReferenceError: program is not defined
  at exports.parse.parse (/Users/chad/dev/noflo-dev/msgflo/src/setup.coffee:173:3)
  at Object.exports.main.main [as main] (/Users/chad/dev/noflo-dev/msgflo/src/setup.coffee:205:13)
  at Object.<anonymous> (/Users/chad/dev/noflo-dev/msgflo/bin/msgflo-setup:4:25)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:935:3
```

Seems like setup.coffee was just missing `program = requires 'commander'`, so I made a quick pull request along with a slight fix to the README. 

Are you all using `msgflo-setup` on your end?  It does not seem like this file ever worked.

