### PR TITLE
More addsource

### DIFF
--- a/spec/protocol.coffee
+++ b/spec/protocol.coffee
@@ -4,9 +4,23 @@ EventEmitter = require('events').EventEmitter
 websocket = require 'websocket'
 fbp = require 'fbp'
 fs = require 'fs'
+path = require 'path'
 
 participants = require './fixtures/participants'
 Runtime = require('../src/runtime').Runtime
+
+rmrf = (dir) ->
+  return if not fs.existsSync dir
+
+  for f in fs.readdirSync dir
+    f = path.join dir, f
+    try
+      fs.unlinkSync f
+    catch e
+      if e.code == 'EISDIR'
+        rmrf f
+      else
+        throw e
 
 class MockUi extends EventEmitter
   constructor: ->
@@ -55,6 +69,7 @@ describe 'FBP runtime protocol', () ->
     componentdir: 'spec/protocoltemp'
 
   before (done) ->
+    rmrf options.componentdir
     fs.rmdirSync options.componentdir if fs.existsSync options.componentdir
     fs.mkdirSync options.componentdir
     runtime = new Runtime options

--- a/src/coordinator.coffee
+++ b/src/coordinator.coffee
@@ -84,12 +84,14 @@ class Coordinator extends EventEmitter
   addParticipant: (definition) ->
     debug 'addParticipant', definition.id
     @participants[definition.id] = definition
+    @library._updateDefinition definition.component, definition
     @emit 'participant-added', definition
     @emit 'participant', 'added', definition
 
   removeParticipant: (id) ->
     definition = @participants[id]
     @emit 'participant-removed', definition
+    @library._updateDefinition definition.component, null
     @emit 'participant', 'removed', definition
 
   addComponent: (name, language, code, callback) ->

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -103,7 +103,17 @@ class Library extends EventEmitter
   _updateComponents: (components) ->
     names = Object.keys components
     for name, comp of components
-      @components[name] = comp
+      if not comp
+        # removed
+        @components[name] = null
+      else if not @components[name]
+        # added
+        @components[name] = comp
+      else
+        # update
+        for k, v of comp
+          @components[name][k] = v
+
     @emit 'components-changed', names, @components
 
   load: (callback) ->
@@ -112,6 +122,14 @@ class Library extends EventEmitter
       @_updateComponents components
       @_updateComponents componentsFromConfig(@options.config)
       return callback null
+
+  # call when MsgFlo discovery message has come in
+  _updateDefinition: (name, def) ->
+    return if not def # Ignore participants being removed
+    changes = {}
+    changes[name] =
+      definition: def
+    @_updateComponents changes
 
   getSource: (name, callback) ->
     debug 'requesting component source', name

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -71,9 +71,10 @@ componentsFromDirectory = (directory, config, callback) ->
         lang = extensionToLanguage[ext]
         component = path.basename(filename, ext)
         debug 'loading component from file', filename, component
+        filepath = path.join directory, filename
         components[component] =
           language: lang
-          command: componentCommandForFile config, filename
+          command: componentCommandForFile config, filepath
 
       return callback null, components
 

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -69,6 +69,7 @@ handleMessage = (proto, sub, cmd, payload, ctx) ->
         subgraph: false
         inPorts: []
         outPorts: []
+      proto.transport.send 'component', 'component', info, ctx
 
     proto.transport.send 'component', 'componentsready', components.length, ctx
     debug 'sent components', components.length

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -189,6 +189,21 @@ class Protocol
     @transport.on 'message', (protocol, command, payload, ctx) =>
       handleMessage @, protocol, command, payload, ctx
 
+    @coordinator.library.on 'components-changed', (names, allComponents) =>
+      debug 'components-changed', names
+      for name in names
+        component = allComponents[name]
+        # TODO: let Library emit a new change when discovery message comes in,
+        # which has inPorts/outPorts info etc
+        info =
+          name: name
+          description: component.cmd
+          icon: null
+          subgraph: false
+          inPorts: []
+          outPorts: []
+        @transport.sendAll 'component', 'component', info
+
     @coordinator.on 'data', (from, fromPort, to, toPort, data) =>
       debug 'on data', from, fromPort, data
 

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -5,6 +5,37 @@
 debug = require('debug')('msgflo:fbp')
 EventEmitter = require('events').EventEmitter
 
+fbpPort = (port) ->
+  m =
+    id: port.id
+    type: port.type or "any"
+    description: port.description or ""
+    addressable: false
+    required: false # TODO: implement
+  return m
+
+fbpComponentFromMsgflo = (name, component) ->
+  if component.definition
+    # full info available
+    info =
+      name: name
+      description: component.label or component.cmd or ""
+      icon: component.definition.icon
+      subgraph: false
+      inPorts: component.definition.inports.map fbpPort
+      outPorts: component.definition.outports.map fbpPort
+  else
+    # just inifial info
+    info =
+      name: name
+      description: component.cmd
+      icon: null
+      subgraph: false
+      inPorts: []
+      outPorts: []
+
+  return info
+
 handleMessage = (proto, sub, cmd, payload, ctx) ->
   debug 'RECV:', sub, cmd, payload
 
@@ -31,46 +62,16 @@ handleMessage = (proto, sub, cmd, payload, ctx) ->
 
   # Component
   else if sub == 'component' and cmd == 'list'
-    getPorts = (participant, type) ->
-      out = []
-      for port in participant[type]
-        m =
-          id: port.id
-          type: port.type
-          description: ""
-          addressable: false
-          required: false # TODO: implement
-        out.push m
-      return out
+
 
     debug 'attempting to list components'
     components = []
-    for name, part of proto.coordinator.participants
-      continue if part.component in components # Avoid duplicates
-      components.push part.component
-      info =
-        name: part.component
-        description: part.label or "" # FIXME: should be .description instead?
-        icon: part.icon
-        subgraph: false # TODO: implement
-        inPorts: getPorts part, 'inports'
-        outPorts: getPorts part, 'outports'
-      proto.transport.send 'component', 'component', info, ctx
-
     for name, component of proto.coordinator.library.components
-      # XXX: we don't know anything about these apart from the name and command
-      # when it has been instantiated first time we'll know the correct values, and should re-send
-      continue if name in components
-      components.push name
-      info =
-        name: name
-        description: component.cmd
-        icon: null
-        subgraph: false
-        inPorts: []
-        outPorts: []
-      proto.transport.send 'component', 'component', info, ctx
+      info = fbpComponentFromMsgflo name, component
+      components.push info
 
+    for info in components
+      proto.transport.send 'component', 'component', info, ctx
     proto.transport.send 'component', 'componentsready', components.length, ctx
     debug 'sent components', components.length
 
@@ -193,15 +194,7 @@ class Protocol
       debug 'components-changed', names
       for name in names
         component = allComponents[name]
-        # TODO: let Library emit a new change when discovery message comes in,
-        # which has inPorts/outPorts info etc
-        info =
-          name: name
-          description: component.cmd
-          icon: null
-          subgraph: false
-          inPorts: []
-          outPorts: []
+        info = fbpComponentFromMsgflo name, component
         @transport.sendAll 'component', 'component', info
 
     @coordinator.on 'data', (from, fromPort, to, toPort, data) =>


### PR DESCRIPTION
Can now add MsgFlo participants, for instance in CoffeeScript using msgflo-nodejs, in Flowhub.
The participant will then appear as an available component, and dragging it to the canvas will instantiate it.