### PR TITLE
Fix initial graph loading not setting up connections

### DIFF
--- a/src/coordinator.coffee
+++ b/src/coordinator.coffee
@@ -67,7 +67,7 @@ waitForParticipant = (coordinator, role, callback) ->
 
   onTimeout = () =>
     return callback new Error "Waiting for participant #{role} timed out"
-  timeout = setTimeout onTimeout, 10000
+  timeout = setTimeout onTimeout, coordinator.options.waitTimeout*1000
 
   onParticipantAdded = (part) =>
     if part.role == role
@@ -89,6 +89,7 @@ class Coordinator extends EventEmitter
     @exported =
       inports: {}
       outports: {}
+    @options.waitTimeout = 40 if not @options.waitTimeout?
 
     @on 'participant', @checkParticipantConnections
 

--- a/src/msgflo.coffee
+++ b/src/msgflo.coffee
@@ -20,6 +20,7 @@ main = () ->
     .option('--ignore [process]', "Don't set up these processes", collectArray, [])
     .option('--forward stderr,stdout', "Forward these streams from child", String, 'stderr,stdout')
     .option('--auto-save [true|false]', "Autosave changes to graph", Boolean, false)
+    .option('--wait-timeout [true|false]', "How long to wait for participants", Number, 45)
     .parse(process.argv)
 
   options = common.normalizeOptions program


### PR DESCRIPTION
Fixes #61 

If discovery takes too long now, it error out with the roles it is waiting for. The waiting time can be specified using the `--wait-timeout` command-line options.
In the future, it would be better if it gave a warning, and properly handled a participant showing up later-than-expected.