### PR TITLE
Send packets as graph "default/main"

### DIFF
--- a/src/coordinator.coffee
+++ b/src/coordinator.coffee
@@ -90,6 +90,7 @@ class Coordinator extends EventEmitter
       inports: {}
       outports: {}
     @options.waitTimeout = 40 if not @options.waitTimeout?
+    @graphName = null
 
     @on 'participant', @checkParticipantConnections
 
@@ -375,6 +376,7 @@ class Coordinator extends EventEmitter
   
   _onConnectionData: (binding, data) =>
     connection = connectionFromBinding @participants, binding
+    connection.graph = @graphName
     @emit 'connection-data', connection, data
 
   subscribeConnection: (fromRole, fromPort, toRole, toPort, callback) ->

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -226,7 +226,7 @@ class Protocol
       id = "#{from}() #{fromPort.toUpperCase()} -> #{toPort.toUpperCase()} #{to}()"
       msg =
         id: id # FIXME: https://github.com/noflo/noflo-ui/issues/293
-        graph: 'main' # FIXME: unhardcode
+        graph: 'default/main' # FIXME: unhardcode
         src:
           node: from
           port: fromPort

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -41,11 +41,10 @@ fbpComponentFromMsgflo = (name, component) ->
 serializeErr = (err) ->
   return { message: err.message }
 
+defaultGraph = 'default/main'
+
 handleMessage = (proto, sub, cmd, payload, ctx) ->
   debug 'RECV:', sub, cmd, payload
-
-  # FIXME: should be 'main' or whatever came from `graph:clear`. However, Flowhub doesn't work with that??
-  defaultGraph = 'default/main'
 
   if sub == 'runtime' and cmd == 'getruntime'
     runtime =
@@ -151,6 +150,7 @@ handleGraphMessage = (proto, cmd, payload, ctx) ->
 
   if cmd == 'clear'
     # FIXME: support multiple graphs
+    proto.coordinator.graphName = payload.id
   else if cmd == 'addnode'
     proto.coordinator.startParticipant payload.id, payload.component, (err) ->
       return proto.transport.send 'graph', 'error', serializeErr(err), ctx if err
@@ -226,7 +226,7 @@ class Protocol
       id = "#{from}() #{fromPort.toUpperCase()} -> #{toPort.toUpperCase()} #{to}()"
       msg =
         id: id # FIXME: https://github.com/noflo/noflo-ui/issues/293
-        graph: 'default/main' # FIXME: unhardcode
+        graph: conn.graph or defaultGraph
         src:
           node: from
           port: fromPort


### PR DESCRIPTION
This fixes packet visibility in Flowhub live mode. However, it also will break project mode.

What we need to do is to make MsgFlo actually aware of the graph(s) it has, and its identifier, and use that throughout.