### PR TITLE
Make componentdir configurable via CLI options

### DIFF
--- a/spec/procfile.coffee
+++ b/spec/procfile.coffee
@@ -19,7 +19,7 @@ describe 'msgflo-procfile', ->
       
       """
       lib = path.join __dirname, 'fixtures', 'library-imgflo.json'
-      options = "--library #{lib} --ignore=imgflo_jobs --ignore=imgflo_api --ignore drop --include 'web: node index.js'"
+      options = "--components participants --library #{lib} --ignore=imgflo_jobs --ignore=imgflo_api --ignore drop --include 'web: node index.js'"
       msgflo_procfile 'imgflo-server.fbp', options, (err, stdout) ->
         chai.expect(err).to.not.exist
         chai.expect(stdout).to.equal expected
@@ -44,7 +44,7 @@ describe 'msgflo-procfile', ->
   describe "missing component in library", ->
     it 'should error with helpful message', (done) ->
       @timeout 4000
-      options = "--ignore=imgflo_jobs --ignore=imgflo_api --ignore drop --include 'web: node index.js'"
+      options = "--components participants --ignore=imgflo_jobs --ignore=imgflo_api --ignore drop --include 'web: node index.js'"
       msgflo_procfile 'imgflo-server.fbp', options, (err, stdout, stderr) ->
         chai.expect(err).to.exist
         chai.expect(stderr).to.contain 'No component'

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -106,7 +106,7 @@ class Library extends EventEmitter
   constructor: (options) ->
     options.config = JSON.parse(fs.readFileSync options.configfile, 'utf-8') if options.configfile
     if not options.componentdir
-      console.error 'WARNING:', 'Default components directory for MsgFlo will change to "components" in next release'
+      console.log 'WARNING:', 'Default components directory for MsgFlo will change to "components" in next release'
       options.componentdir = 'participants'
     options.config = normalizeConfig options.config
     @options = options

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -105,7 +105,9 @@ normalizeConfig = (config) ->
 class Library extends EventEmitter
   constructor: (options) ->
     options.config = JSON.parse(fs.readFileSync options.configfile, 'utf-8') if options.configfile
-    options.componentdir = 'participants' if not options.componentdir
+    if not options.componentdir
+      console.error 'WARNING:', 'Default components directory for MsgFlo will change to "components" in next release'
+      options.componentdir = 'participants'
     options.config = normalizeConfig options.config
     @options = options
 

--- a/src/msgflo.coffee
+++ b/src/msgflo.coffee
@@ -23,6 +23,7 @@ main = () ->
     .option('--broker <uri>', 'Broker address', String, '')
     .option('--ide <uri>', 'FBP IDE address', String, 'http://app.flowhub.io')
     .option('--library <FILE.json>', 'Library configuration file', String, 'package.json')
+    .option('--componentdir <dirname>', 'Library directory', String, 'participants')
     .option('--graph <file.json>', 'Initial graph to load', String, '')
     .option('--ignore [process]', "Don't set up these processes", collectArray, [])
     .option('--forward <stderr,stdout>', "Forward these streams from child", String, 'stderr,stdout')

--- a/src/msgflo.coffee
+++ b/src/msgflo.coffee
@@ -23,7 +23,7 @@ main = () ->
     .option('--broker <uri>', 'Broker address', String, '')
     .option('--ide <uri>', 'FBP IDE address', String, 'http://app.flowhub.io')
     .option('--library <FILE.json>', 'Library configuration file', String, 'package.json')
-    .option('--componentdir <dirname>', 'Library directory', String, 'participants')
+    .option('--componentdir <dirname>', 'Library directory', String, '')
     .option('--graph <file.json>', 'Initial graph to load', String, '')
     .option('--ignore [process]', "Don't set up these processes", collectArray, [])
     .option('--forward <stderr,stdout>', "Forward these streams from child", String, 'stderr,stdout')

--- a/src/procfile.coffee
+++ b/src/procfile.coffee
@@ -62,7 +62,7 @@ exports.parse = parse = (args) ->
     .option('--library <FILE.json>', 'Use FILE.json as the library definition', String, 'package.json')
     .option('--ignore [NODE]', 'Do not generate output for NODE. Can be specified multiple times.', addIgnore, [])
     .option('--include [DATA]', 'Include DATA as-is in generated file. Can be specified multiple times.', addInclude, [])
-    .option('--components <DIR>', 'Lookup components from DIR', String, '')
+    .option('--components <DIR>', 'Lookup components from DIR', String, 'participants')
     .action (gr, env) ->
       graph = gr
     .parse args

--- a/src/setup.coffee
+++ b/src/setup.coffee
@@ -281,7 +281,7 @@ exports.participants = setupParticipants = (options, callback) ->
   common.readGraph options.graphfile, (err, graph) ->
     return callback err if err
 
-    lib = new Library { configfile: options.libraryfile }
+    lib = new Library { configfile: options.libraryfile, componentdir: options.componentdir }
     lib.load (err) ->
       return callback err if err
       commands = participantCommands graph, lib, options.only, options.ignore
@@ -296,6 +296,7 @@ exports.parse = parse = (args) ->
     .option('--only <one,two,three>', 'Only set up participants for these roles', String, '')
     .option('--ignore <one,two,three>', 'Do not set up participants for these roles', String, null)
     .option('--library <FILE.json>', 'Library definition to use', String, 'package.json')
+    .option('--componentdir <DIR>', 'Directory where components are located', String, '')
     .option('--forward [stderr,stdout]', 'Forward child process stdout and/or stderr', String, '')
     .option('--discover [BOOL]', 'Whether to wait for FBP discovery messages for queue info', Boolean, false)
     .option('--timeout <SECONDS>', 'How long to wait for discovery messages', Number, 30)


### PR DESCRIPTION
This enables projects to use an arbitrary component directory instead of `participants/`. Improved Flowhub compatibility since Flowhub expects components to live in `components/`