### PR TITLE
Fix getSource

### DIFF
--- a/src/library.coffee
+++ b/src/library.coffee
@@ -148,7 +148,7 @@ class Library extends EventEmitter
         continue
       discovered = cleanComponentDefinition comp
       existing = @getComponent name
-      unless existing?.definition
+      unless existing
         # added
         @components[name] = discovered
         names.push name if names.indexOf(name) is -1


### PR DESCRIPTION
Fixes regression caused by #129 that would make getSource not work:
![screenshot 2017-06-01 at 19 47 45](https://cloud.githubusercontent.com/assets/3346/26693797/b50331fe-4705-11e7-9f9e-9277f70f3388.png)

