### PR TITLE
Send repository URL, not object

### DIFF
--- a/src/library.coffee
+++ b/src/library.coffee
@@ -91,7 +91,7 @@ normalizeConfig = (config) ->
     repository = config.repository.url
   config = config.msgflo if config.msgflo # Migth be under a .msgflo key, for instance in package.json
 
-  config.repository = repository if not config.repository?
+  config.repository = repository unless typeof config.repository is 'string'
   config.namespace = namespace if not config.namespace?
   config.components = {} if not config.components
   config.variables = {} if not config.variables

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -63,8 +63,6 @@ handleMessage = (proto, sub, cmd, payload, ctx) ->
     options = proto.coordinator.library.options
     runtime.namespace = options.config.namespace if options.config?.namespace?
     runtime.repository = options.config.repository if options.config?.repository?
-    if typeof runtime.repository is 'object' and runtime.repository.url
-      runtime.repository = runtime.repository.url
     proto.transport.send 'runtime', 'runtime', runtime, ctx
 
   else if sub == 'runtime' and cmd == 'packet'

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -63,6 +63,8 @@ handleMessage = (proto, sub, cmd, payload, ctx) ->
     options = proto.coordinator.library.options
     runtime.namespace = options.config.namespace if options.config?.namespace?
     runtime.repository = options.config.repository if options.config?.repository?
+    if typeof runtime.repository is 'object' and runtime.repository.url
+      runtime.repository = runtime.repository.url
     proto.transport.send 'runtime', 'runtime', runtime, ctx
 
   else if sub == 'runtime' and cmd == 'packet'


### PR DESCRIPTION
Current MsgFlo sends:

```json
"repository": {
  "type": "git",
  "url": "..."
}
```

instead of just repository URL as specified in fbp protocol