### PR TITLE
External component getSource

### DIFF
--- a/src/library.coffee
+++ b/src/library.coffee
@@ -198,8 +198,8 @@ class Library extends EventEmitter
       source =
         name: basename
         library: library
-        code: '' # TODO: discovery data in YAML
-        language: 'yaml'
+        code: JSON.stringify(component.definition or {}, null, 2)
+        language: 'discovery'
       return callback null, source
 
     lang = component.language

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -183,8 +183,7 @@ class Library extends EventEmitter
     debug 'requesting component source', name
     component = @getComponent name
     return callback new Error "Component not found for #{name}" unless component
-    lang = component.language
-    ext = languageExtensions[lang]
+
     basename = name
     library = null
     if name.indexOf('/') isnt -1
@@ -192,6 +191,19 @@ class Library extends EventEmitter
       [library, basename] = name.split '/'
     else if @options.config?.namespace?
       library = @options.config?.namespace
+
+    unless component.language
+      # Component that doesn't come from handlers, send discovery info since source isn't available
+      debug 'component without source', name, component.command
+      source =
+        name: basename
+        library: library
+        code: '' # TODO: discovery data in YAML
+        language: 'yaml'
+      return callback null, source
+
+    lang = component.language
+    ext = languageExtensions[lang]
     filename = path.join @options.componentdir, "#{basename}.#{ext}"
     fs.readFile filename, 'utf-8', (err, code) ->
       debug 'component source file', filename, lang, err

--- a/src/library.coffee
+++ b/src/library.coffee
@@ -1,6 +1,7 @@
 
 fs = require 'fs'
 path = require 'path'
+yaml = require 'js-yaml'
 debug = require('debug')('msgflo:library')
 EventEmitter = require('events').EventEmitter
 
@@ -198,7 +199,7 @@ class Library extends EventEmitter
       source =
         name: basename
         library: library
-        code: JSON.stringify(component.definition or {}, null, 2)
+        code: yaml.safeDump component.definition or {}
         language: 'discovery'
       return callback null, source
 


### PR DESCRIPTION
Adds rudimentary `getSource` support for external components (that MsgFlo didn't start by its handlers). Sends the discovery message as the "source"

![screenshot 2017-07-06 at 16 12 19](https://user-images.githubusercontent.com/3346/27915218-e887d5f4-6265-11e7-894f-46e28bf4bcf8.png)

![screenshot 2017-07-06 at 16 12 12](https://user-images.githubusercontent.com/3346/27915224-ecff824e-6265-11e7-86f5-c4ba406bf5d7.png)

Fixes #147

