### PR TITLE
Support JSON schemas on ports

### DIFF
--- a/site/_documentation/communications.md
+++ b/site/_documentation/communications.md
@@ -23,9 +23,7 @@ The network coordinator subscribes to a queue named `fbp`.
 Once a participant becomes available, it announces its availability by sending a message to this queue
 with `protocol`: 'discovery' and `command`: 'participant'.
 
-In case of systems incapable of communicating via FBP protocol
-but which can nonetheless be connected to a network,
-the message `payload` contains the following information:
+The message `payload` contains the following information:
 
 * `id`: short unique name for the participant. Ex: measure1
 * `role`: the role this participant has in the network. Used to group multiple partipants. Ex: measure
@@ -36,12 +34,14 @@ the message `payload` contains the following information:
   - `id`: port name
   - `queue`: the message queue the process listens to
   - `type`: port datatype, for example `boolean`
-  - `options`: queue options as specified by the message queue implementation
+  - `schema`: (optional) URL to a JSON schema for data expected on port
+  - `options`: (optional) queue options as specified by the message queue implementation
 * `outports`: list of outports containing:
   - `id`: port name
   - `queue`: the message queue the process transmits to
   - `type`: port datatype, for example `boolean`
-  - `options`: queue options as specified by the message queue implementation
+  - `schema`: (optional) URL to a JSON schema for data sent on port
+  - `options`: (optional) queue options as specified by the message queue implementation
 
 If the participant is itself implemented using FBP and supports the
 [FBP runtime protocol](https://flowbased.github.io/fbp-protocol/), these additional keys should be defined.

--- a/site/_documentation/communications.md
+++ b/site/_documentation/communications.md
@@ -34,12 +34,14 @@ The message `payload` contains the following information:
   - `id`: port name
   - `queue`: the message queue the process listens to
   - `type`: port datatype, for example `boolean`
+  - `description`: (optional) Human-readable description of the port and its function
   - `schema`: (optional) URL to a JSON schema for data expected on port
   - `options`: (optional) queue options as specified by the message queue implementation
 * `outports`: list of outports containing:
   - `id`: port name
   - `queue`: the message queue the process transmits to
   - `type`: port datatype, for example `boolean`
+  - `description`: (optional) Human-readable description of the port and its function
   - `schema`: (optional) URL to a JSON schema for data sent on port
   - `options`: (optional) queue options as specified by the message queue implementation
 

--- a/src/protocol.coffee
+++ b/src/protocol.coffee
@@ -11,6 +11,7 @@ fbpPort = (port) ->
     id: port.id
     type: port.type or "any"
     description: port.description or ""
+    schema: port.schema # optional
     addressable: false
     required: false # TODO: implement
   return m


### PR DESCRIPTION
Ref https://github.com/flowbased/fbp-protocol/pull/50

Punting on packet-level type/schema support, since it is a bit trickier. Putting it in the on-wire payload will change the data, which may affect compatibility with external consumers. A opt-in convention for how to store it might be acceptable, like `__msgflo_schema: https://example.net/schema/foo.json`. Msgflo libraries could optionally lift the data out of payload and expose as `schema` on the incoming message.