### PR TITLE
Fix wrong path for send import

### DIFF
--- a/bin/msgflo-send-message
+++ b/bin/msgflo-send-message
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../bin/utils/send').main()
+require('../lib/utils/send').main()


### PR DESCRIPTION
msgflo-send-message does not work with the wrong import. See issue [#180](https://github.com/msgflo/msgflo/issues/180) for the bug report. 

It's just a small fix, but currently the [tutorial](https://msgflo.org/docs/usage/index.html) is not working because of it.